### PR TITLE
Improve Recipe Display: Sticky Tabs, Subcategory Reset, Preview Fix, and Pager Transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+app/release

--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/sh/deut/recipeapp/ui/RecipeViewModel.kt
+++ b/app/src/main/java/sh/deut/recipeapp/ui/RecipeViewModel.kt
@@ -48,12 +48,15 @@ class RecipeViewModel(
     }
 
     fun subcategorySelected(subCategory: SubCategory) {
-        _uiState.update { currentState ->
-            currentState.copy(
-                subcategoryName = subCategory.name
-            )
+        if (selectedSubCategory != subCategory) {
+            _uiState.update { currentState ->
+                currentState.copy(
+                    subcategoryName = subCategory.name,
+                    subcategoryRecipes = emptyList(),
+                )
+            }
+            selectedSubCategory = subCategory
         }
-        selectedSubCategory = subCategory
     }
 
     fun initializeRecipes() {
@@ -99,13 +102,16 @@ class RecipeViewModel(
     }
 
     fun updateSelectedRecipe(recipe: PartialRecipe) {
-        viewModelScope.launch {
-            val fullRecipe = recipeRepository.getSelectedRecipe(recipeId = recipe.id)
-            selectedRecipe = fullRecipe
-            _uiState.update { currentState ->
-                currentState.copy(
-                    selectedRecipeName = recipe.name, selectedRecipe = recipeToUiRecipe(fullRecipe)
-                )
+        if (selectedRecipe?.id != recipe.id) {
+            viewModelScope.launch {
+                val fullRecipe = recipeRepository.getSelectedRecipe(recipeId = recipe.id)
+                selectedRecipe = fullRecipe
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        selectedRecipeName = recipe.name,
+                        selectedRecipe = recipeToUiRecipe(fullRecipe)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/sh/deut/recipeapp/ui/selectedrecipescreen/RecipePartTab.kt
+++ b/app/src/main/java/sh/deut/recipeapp/ui/selectedrecipescreen/RecipePartTab.kt
@@ -4,8 +4,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -34,7 +38,8 @@ fun RecipePartTab(
     onIngredientCheckedChanged: (Boolean, Int) -> Unit
 ) {
     Column(
-        modifier = modifier.padding(dimensionResource(R.dimen.padding_small)),
+        modifier = modifier
+            .padding(dimensionResource(R.dimen.padding_small))
     ) {
         Text(
             modifier = Modifier.padding(bottom = dimensionResource(R.dimen.padding_small)),

--- a/app/src/main/java/sh/deut/recipeapp/ui/selectedrecipescreen/SelectedRecipeScreen.kt
+++ b/app/src/main/java/sh/deut/recipeapp/ui/selectedrecipescreen/SelectedRecipeScreen.kt
@@ -1,6 +1,7 @@
 package sh.deut.recipeapp.ui.selectedrecipescreen
 
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,10 +12,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
@@ -73,10 +73,9 @@ fun SelectedRecipeScreen(
         },
         contentPadding
     )
-
 }
 
-
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SelectedRecipeLayout(
     modifier: Modifier = Modifier,
@@ -87,90 +86,106 @@ fun SelectedRecipeLayout(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { recipe.recipeParts.size })
-    Column(
+
+    LazyColumn(
         modifier = modifier
             .padding(contentPadding)
-            .verticalScroll(rememberScrollState())
             .fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_small)),
         horizontalAlignment = Alignment.Start
     ) {
-        Text(
-            text = recipe.name,
-            style = MaterialTheme.typography.headlineMedium,
-            modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.padding_small))
-        )
-
-        Text(
-            text = recipe.description,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(dimensionResource(R.dimen.padding_small))
-        )
-
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current).crossfade(500).data(recipe.imgUrl)
-                .build(),
-            contentDescription = stringResource(R.string.recipe_image_content_desc),
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(Color.LightGray)
-                .size(220.dp)
-                .padding(horizontal = dimensionResource(R.dimen.padding_small)),
-        )
-
-        Row(
-            modifier = Modifier.padding(dimensionResource(R.dimen.padding_small)),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconAndTextColumn(
-                title = "Total time",
-                icon = R.drawable.clock_svgrepo_com,
-                iconDescription = stringResource(R.string.clock_icon),
-                mainText = cookTimeFormater(recipe.cookTime.readyIn)
-            )
-            IconAndTextColumn(
-                title = "Prep time",
-                icon = R.drawable.hat_chef_svgrepo_com,
-                iconDescription = stringResource(R.string.prep_icon),
-                mainText = cookTimeFormater(recipe.cookTime.handsOn)
+        item {
+            Text(
+                text = recipe.name,
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.padding_small))
             )
 
-        }
-        TabRow(
-            selectedTabIndex = pagerState.currentPage,
-            modifier = Modifier.padding(dimensionResource(R.dimen.padding_small))
-        ) {
-            recipe.recipeParts.forEachIndexed { index, item ->
-                Tab(
-                    selected = index == pagerState.currentPage,
-                    text = {
-                        Text(
-                            text = item.name, maxLines = 2, overflow = TextOverflow.Ellipsis
-                        )
-                    },
-                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+            Text(
+                text = recipe.description,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(dimensionResource(R.dimen.padding_small))
+            )
+
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current).crossfade(500)
+                    .data(recipe.imgUrl).build(),
+                contentDescription = stringResource(R.string.recipe_image_content_desc),
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.LightGray)
+                    .size(220.dp)
+                    .padding(horizontal = dimensionResource(R.dimen.padding_small)),
+            )
+
+            Row(
+                modifier = Modifier.padding(dimensionResource(R.dimen.padding_small)),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconAndTextColumn(
+                    title = "Total time",
+                    icon = R.drawable.clock_svgrepo_com,
+                    iconDescription = stringResource(R.string.clock_icon),
+                    mainText = cookTimeFormater(recipe.cookTime.readyIn)
                 )
+                IconAndTextColumn(
+                    title = "Prep time",
+                    icon = R.drawable.hat_chef_svgrepo_com,
+                    iconDescription = stringResource(R.string.prep_icon),
+                    mainText = cookTimeFormater(recipe.cookTime.handsOn)
+                )
+
             }
         }
-        HorizontalPager(
-            state = pagerState
-        ) { page ->
-            RecipePartTab(
-                recipePart = recipe.recipeParts[page],
-                onIngredientCheckedChanged = { isChecked, inIndex ->
-                    updateRecipeIngredientSelectionState(
-                        recipe.id, pagerState.currentPage, inIndex, isChecked
+
+        stickyHeader {
+            TabRow(
+                selectedTabIndex = pagerState.currentPage, modifier = Modifier
+            ) {
+                recipe.recipeParts.forEachIndexed { index, item ->
+                    Tab(
+                        selected = index == pagerState.currentPage,
+                        text = {
+                            Text(
+                                text = item.name, maxLines = 2, overflow = TextOverflow.Ellipsis
+                            )
+                        },
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(
+                                    index
+                                )
+                            }
+                        },
                     )
-                },
-                onInstructionCheckedChanged = { isChecked, insIndex ->
-                    updateRecipeInstructionSelectionState(
-                        recipe.id, pagerState.currentPage, insIndex, isChecked
-                    )
-                })
+                }
+            }
+        }
+
+        item {
+            HorizontalPager(
+                state = pagerState,
+                verticalAlignment = Alignment.Top,
+                modifier = Modifier.fillMaxWidth()
+            ) { page ->
+                RecipePartTab(
+                    recipePart = recipe.recipeParts[page],
+                    onIngredientCheckedChanged = { isChecked, inIndex ->
+                        updateRecipeIngredientSelectionState(
+                            recipe.id, pagerState.currentPage, inIndex, isChecked
+                        )
+                    },
+                    onInstructionCheckedChanged = { isChecked, insIndex ->
+                        updateRecipeInstructionSelectionState(
+                            recipe.id, pagerState.currentPage, insIndex, isChecked
+                        )
+                    })
+            }
         }
     }
 }
+
 
 @Composable
 fun IconAndTextColumn(
@@ -211,7 +226,22 @@ fun SelectedRecipeScreenPreview() {
         CookTime(30.toDuration(DurationUnit.MINUTES), 45.toDuration(DurationUnit.MINUTES)),
         listOf(
             UiRecipePart(
-                "A", listOf(UiIngredient("flour"), UiIngredient("egg")), listOf(
+                "A", listOf(
+                    UiIngredient("flour"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg"),
+                    UiIngredient("egg")
+                ), listOf(
                     UiInstruction("mix"), UiInstruction("form")
                 )
             ), UiRecipePart(


### PR DESCRIPTION
This PR addresses several display issues in the RecipeApp interface:

1. Subcategory Selection Reset:

- Previously selected subcategories are now cleared immediately when a new subcategory is chosen, preventing lingering states.

2. Preview Fix:

- Resolved an issue where the recipe preview was not rendering correctly.

3. Sticky Tab Row:

- The tab row in the recipe display now remains visible (“sticky”) when scrolling, improving navigation and usability.

4. Pager Transition Bug:

- Updated the pager logic to fix buggy transitions between recipe tabs, ensuring smooth navigation and consistent tab behavior.